### PR TITLE
[Tabs] Added the ability to set a default tab

### DIFF
--- a/docs/src/components/tabs.md
+++ b/docs/src/components/tabs.md
@@ -23,6 +23,13 @@
 
 The tabs to display. The `key` is the tab id and the value is the tab label. The tab id must match the slot name (e.g `<template #tab1>` in the above [example](#usage)).
 
+### `defaultTab` <Badge text="optional" type="tip" />
+
+- Type: `number`
+- Default: `0`
+
+The initial active tab index.
+
 ### `justified` <Badge text="optional" type="tip" />
 
 - Type: `boolean`

--- a/src/components/Tabs/Tabs.vue
+++ b/src/components/Tabs/Tabs.vue
@@ -27,10 +27,16 @@ export default {
   name: "WinuiTabs",
   props: {
     tabs: { type: Object, required: true },
+    defaultTab: { type: Number, default: 0 },
     justified: Boolean,
   },
   data() {
-    return { activeTab: Object.keys(this.tabs)[0] };
+    const tabsLength = Object.keys(this.tabs).length;
+    return {
+      activeTab: Object.keys(this.tabs)[
+        Math.max(Math.min(this.defaultTab, tabsLength - 1), 0)
+      ],
+    };
   },
   methods: {
     change(tab) {


### PR DESCRIPTION
## What's new:

Added the ability to set an initial active tab index besides the default first tab.

If the index falls outside the tabs' length range, it's clamped to the nearest valid index number.

Please let me know if there's any problem.